### PR TITLE
Fix issues related to notes

### DIFF
--- a/src/public/assets/js/notes/renderNoteDiv.js
+++ b/src/public/assets/js/notes/renderNoteDiv.js
@@ -1015,7 +1015,7 @@ function renderNote(noteData) {
 
     // create the submenu to show when "more" is clicked
     const moreSubMenu = document.createElement("div");
-    if (firebase.auth().currentUser.uid === noteData.whoSentIt) {
+    if (firebase.auth().currentUser && firebase.auth().currentUser.uid === noteData.whoSentIt) {
         moreSubMenu.innerHTML = `
             <button onclick="createEditNoteUI('${noteData.id}');">${faIcon("pen-to-square").outerHTML} Edit Note</button>
             <button class="danger" onclick="createDeleteNoteUI('${noteData.id}')">${faIcon("trash").outerHTML} Delete Note</button>

--- a/src/public/assets/js/versioning.js
+++ b/src/public/assets/js/versioning.js
@@ -1,5 +1,5 @@
-let aurideVersion = "v2025.10.7";
-let aurideUpdate = "v20251007-3";
+let aurideVersion = "v2025.10.11";
+let aurideUpdate = "v20251011-3";
 let aurideReleaseVersion = "alpha";
 let hasUpdateNotes = true;
 

--- a/src/updates.html
+++ b/src/updates.html
@@ -136,6 +136,16 @@
                         <p>Trying to find older updates? You may be interested in the Pre-Alpha tab, since Auride is no longer in Pre-Alpha!</p>
 
                         <div class="update">
+                            <h2>v2025.10.11_alpha</h2>
+                            <h3 style="color: var(--text-semi-transparent);">Released: October 11, 2025</h3>
+                                <li>Fixed signed out users not being able to view notes</li>
+                                <li>(Hopefully) fixed note sorting issues</li>
+                                <li>Fixed notes from deleted users showing up</li>
+                        </div>
+                        
+                        <br />
+
+                        <div class="update">
                             <h2>v2025.10.7_alpha</h2>
                             <h3 style="color: var(--text-semi-transparent);">Released: October 7, 2025</h3>
                                 <li>Fixed favorites not showing up on the favorites page</li>


### PR DESCRIPTION
### Description of Changes
---
Fixes 3 issues related to notes:
- Signed out users not being able to view them, as there as a Firebase auth check that did not check if there was a user, causing notes to fail to load at all for anyone signed out.
- Fixed note sorting issues, it seems that an `undefined` users will throw Auride off, and cause random issues... at least, this is my understanding. I have not been able to reproduce this issue after these changes, but this does not mean definitively that the issue is fixed.
- The server will now check user data to see if the user is deleted (or has account issues), which will make them not render on the screen whatsoever, fixing "undefined" users.

### Visual Sample
---
<img width="1918" height="1007" alt="image" src="https://github.com/user-attachments/assets/88e2f5f1-4513-4fc4-be0d-1084a022924a" />

<img width="1918" height="1007" alt="image" src="https://github.com/user-attachments/assets/d68f031c-32f4-4b9d-91f0-5704eced24b5" />


### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
  - You agree that you have tested your changes, and that you are not opening a Pull Request that you're unsure if it works.
- [x] I confirm I have not contributed anything that would impact Auride's licensing and/or usage
  - Auride is a **commercial** product that Katniny Studios can profit from. Please do not add copyrighted material to your Pull Request, however there are exceptions (e.g. our Spotify integration).
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
  - This includes things such as security vulnerabilities, ways to manipulate data, etc.
- [x] I've read the latest [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md) (last updated: September 15, 2025) and will follow the guidelines
  - Please make sure to read it, we use this as the standard when reviewing contributions, so it's in your best interest to be familiar with it!
- [x] I updated the version and added the update log
  - Unsure what this means? Please read [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md).