### PR TITLE
Fix hashtags not working after a <br />

### DIFF
--- a/src/public/assets/js/ts_fas_acih.js
+++ b/src/public/assets/js/ts_fas_acih.js
@@ -920,10 +920,9 @@ function emojify(text) {
 }
 
 function hashtagify(text) {
-   return text.replace(/(^|\s)#([\w-]+)/g, (match, space, tag) => {
-      // create link html
+   return text.replace(/(^|\s|>)#([\w-]+)/g, (match, prefix, tag) => {
       const link = `<a href="/search?q=#${tag.toLowerCase()}">#${tag}</a>`;
-      return space + link;
+      return prefix + link;
    });
 }
 


### PR DESCRIPTION
### Description of Changes
---
Fixes hashtags not working on a new line, specifically after a breakpoint.

The regex was not accounting for this, even if it was accounting for new lines.

### Visual Sample
---
<img width="956" height="194" alt="image" src="https://github.com/user-attachments/assets/0c842424-164e-43bd-b575-9edb3e5ee3df" />


### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
  - You agree that you have tested your changes, and that you are not opening a Pull Request that you're unsure if it works.
- [x] I confirm I have not contributed anything that would impact Auride's licensing and/or usage
  - Auride is a **commercial** product that Katniny Studios can profit from. Please do not add copyrighted material to your Pull Request, however there are exceptions (e.g. our Spotify integration).
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
  - This includes things such as security vulnerabilities, ways to manipulate data, etc.
- [x] I've read the latest [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md) (last updated: September 15, 2025) and will follow the guidelines
  - Please make sure to read it, we use this as the standard when reviewing contributions, so it's in your best interest to be familiar with it!
- [x] I updated the version and added the update log
  - Unsure what this means? Please read [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md).