### PR TITLE
Optimize notification loading

### DIFF
--- a/src/assets/css/notifications.css
+++ b/src/assets/css/notifications.css
@@ -26,3 +26,20 @@
 .notification i {
    margin-right: 10px;
 }
+
+/* loved notification type */
+.notification.loved i {
+   color: var(--like-color);
+}
+
+.notification.renoted i {
+   color: var(--renote-color);
+}
+
+.notification.mentioned i {
+   color: var(--main-color);
+}
+
+.notification.followed i {
+   color: var(--main-color);
+}

--- a/src/public/assets/js/firebase.js
+++ b/src/public/assets/js/firebase.js
@@ -2,7 +2,7 @@
 
 // this contains the firebase config and initializes firebase
 // before pushing to git, always make sure the firebase config doesn't expose your keys
-// TO:DO finish https://github.com/katniny/Auride/tree/module-upgrade then move this to a .env file!
+// TODO finish https://github.com/katniny/Auride/tree/module-upgrade then move this to a .env file!
 
 /** @satisfies {import("firebase/app").FirebaseOptions} */
 const firebaseConfig = {

--- a/src/public/assets/js/notes/notes.js
+++ b/src/public/assets/js/notes/notes.js
@@ -1,4 +1,4 @@
-// TO:DO - seperate this code!
+// TODO - seperate this code!
 // its just in a new script for 
 // 1) code seperation, since i would like to depreciate ts_fas_acih.js
 // 2) bug fixing
@@ -146,7 +146,7 @@ async function loadInitalNotes() {
     currentLoadingNotes = true;
 
     // create loading indicator to give some visual feedback
-    await createLoadingIndicator("lg", "notes");
+    await createLoadingIndicator("lg", "notes", "append");
     const loadingIndicator = document.getElementById("noteLoadingIndicator");
     
     // fetch note data from server
@@ -190,7 +190,7 @@ async function loadMoreNotes() {
     currentLoadingNotes = true;
 
     // create loading indicator to give some visual feedback
-    createLoadingIndicator("lg", "notes");
+    createLoadingIndicator("lg", "notes", "append");
     const loadingIndicator = document.getElementById("noteLoadingIndicator");
     
     // fetch note data from server

--- a/src/public/assets/js/ui/loadingIndicator.js
+++ b/src/public/assets/js/ui/loadingIndicator.js
@@ -1,5 +1,5 @@
 // create loading indicator to give some visual feedback
-function createLoadingIndicator(size, appendTo) {
+function createLoadingIndicator(size, appendTo, addType) {
     // get the size requested
     let loadingIndicator = null;
     switch (size) {
@@ -29,5 +29,8 @@ function createLoadingIndicator(size, appendTo) {
 
     // append element
     // should an id, NOT a class!
-    document.getElementById(appendTo).appendChild(loadingIndicator);
+    if (addType === "append")
+        document.getElementById(appendTo).appendChild(loadingIndicator);
+    else if (addType === "prepend")
+        document.getElementById(appendTo).prepend(loadingIndicator);
 }

--- a/src/public/assets/js/versioning.js
+++ b/src/public/assets/js/versioning.js
@@ -1,5 +1,5 @@
-let aurideVersion = "v2025.10.14";
-let aurideUpdate = "v20251014-1";
+let aurideVersion = "v2025.10.15";
+let aurideUpdate = "v20251015-1";
 let aurideReleaseVersion = "alpha";
 let hasUpdateNotes = true;
 

--- a/src/updates.html
+++ b/src/updates.html
@@ -136,9 +136,19 @@
                         <p>Trying to find older updates? You may be interested in the Pre-Alpha tab, since Auride is no longer in Pre-Alpha!</p>
 
                         <div class="update">
+                            <h2>v2025.10.15_alpha</h2>
+                            <h3 style="color: var(--text-semi-transparent);">Released: October 15, 2025</h3>
+                                <li>Notifications will now load in batches of 15 rather than all at once, improving performance & load times on the notifications page significantly</li>
+                                <li>Fixed notification icons not having color</li>
+                        </div>
+                        
+                        <br />
+
+                        <div class="update">
                             <h2>v2025.10.14_alpha</h2>
                             <h3 style="color: var(--text-semi-transparent);">Released: October 14, 2025</h3>
                                 <li>Added hashtag support because <a href="/search?q=#WeHeckinLoveHashtags">#WeHeckinLoveHashtags</a></li>
+                                <li>Fixed hashtags not working on new lines</li>
                         </div>
                         
                         <br />


### PR DESCRIPTION
### Description of Changes
---
Instead of loading all the users notifications at once (e.g., if they had 1,000 notifications, we would load all 1,000 at ONCE), Auride will now load 15 notifications at a time, increasing performance and load times significantly.

### Visual Sample
---

https://github.com/user-attachments/assets/eb74e7cc-d192-4598-88a4-8872ec7d3a65



### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
  - You agree that you have tested your changes, and that you are not opening a Pull Request that you're unsure if it works.
- [x] I confirm I have not contributed anything that would impact Auride's licensing and/or usage
  - Auride is a **commercial** product that Katniny Studios can profit from. Please do not add copyrighted material to your Pull Request, however there are exceptions (e.g. our Spotify integration).
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
  - This includes things such as security vulnerabilities, ways to manipulate data, etc.
- [x] I've read the latest [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md) (last updated: September 15, 2025) and will follow the guidelines
  - Please make sure to read it, we use this as the standard when reviewing contributions, so it's in your best interest to be familiar with it!
- [x] I updated the version and added the update log
  - Unsure what this means? Please read [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md).