### PR TITLE
Return post year if not from current year

### DIFF
--- a/src/public/assets/js/ts_fas_acih.js
+++ b/src/public/assets/js/ts_fas_acih.js
@@ -3378,27 +3378,40 @@ function timeAgo(timestamp) {
    const now = Math.floor(Date.now() / 1000); // Current timestamp in seconds
    const seconds = now - Math.floor(timestamp / 1000); // Convert milliseconds to seconds
 
+   // if seconds...
    if (seconds < 60) {
       return `${seconds}s`;
    }
+   // minutes...
    const minutes = Math.floor(seconds / 60);
    if (minutes < 60) {
       return `${minutes}m`;
    }
+   // hours...
    const hours = Math.floor(minutes / 60);
    if (hours < 24) {
       return `${hours}h`;
    }
+   // days...
    const days = Math.floor(hours / 24);
    if (days < 30) {
       return `${days}d`;
    }
 
+   // get the month
    const date = new Date(timestamp);
-   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-   // TODO: show year if relevant
-   return `${months[date.getMonth()]} ${date.getDate()}`;
+   // get current year
+   const currentYear = new Date().getFullYear();
+   const postYear = date.getFullYear();
+
+   // return with year, if current year is not the same as note date
+   if (postYear !== currentYear)
+      return `${months[date.getMonth()]} ${date.getDate()}, ${postYear}`;
+   // or, if it is the same, return without year
+   else
+      return `${months[date.getMonth()]} ${date.getDate()}`;
 }
 
 // Check unlocked achievements on achievement page

--- a/src/public/assets/js/versioning.js
+++ b/src/public/assets/js/versioning.js
@@ -1,5 +1,5 @@
 let aurideVersion = "v2025.10.16";
-let aurideUpdate = "v20251016-2";
+let aurideUpdate = "v20251016-3";
 let aurideReleaseVersion = "alpha";
 let hasUpdateNotes = true;
 

--- a/src/updates.html
+++ b/src/updates.html
@@ -78,6 +78,7 @@
                                     <li style="margin-left: 35px; color: var(--text-semi-transparent); font-size: smaller;">If you're a user and notice new header issues, <a href="https://github.com/katiny/Auride/issues">let us know</a>!</li>
                                 <li>Fixed signed out users getting the same interactions in the header as a signed in user</li>
                                 <li>Fixed the search bar in the header not working</li>
+                                <li>Fixed notes from a different year showing up as if they were from this year (e.g., "April 11" instead of "April 11, 2024")</li>
                         </div>
                         
                         <br />


### PR DESCRIPTION
### Description of Changes
---
This will return `{month} {day}, {year}` if a note is not from the current year.

Only 8 months and 16 days past due... shh...

### Visual Sample
---
<img width="960" height="851" alt="image" src="https://github.com/user-attachments/assets/62fedde1-3f09-48ae-b6aa-4e36319f6ed0" />

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
  - You agree that you have tested your changes, and that you are not opening a Pull Request that you're unsure if it works.
- [x] I confirm I have not contributed anything that would impact Auride's licensing and/or usage
  - Auride is a **commercial** product that Katniny Studios can profit from. Please do not add copyrighted material to your Pull Request, however there are exceptions (e.g. our Spotify integration).
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
  - This includes things such as security vulnerabilities, ways to manipulate data, etc.
- [x] I've read the latest [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md) (last updated: September 15, 2025) and will follow the guidelines
  - Please make sure to read it, we use this as the standard when reviewing contributions, so it's in your best interest to be familiar with it!
- [x] I updated the version and added the update log
  - Unsure what this means? Please read [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md).