### PR TITLE
Fixed some users not showing up on timeline

### DIFF
--- a/server/auride/getNoteData.js
+++ b/server/auride/getNoteData.js
@@ -117,7 +117,7 @@ router.get("/api/auride/getNoteData", async (req, res) => {
         await Promise.all(promises);
 
         // return :)
-        res.json(notesArray.slice(0, limit));
+        res.json(notesArray);
     } catch (err) {
         console.error(err);
         res.status(500).json({ error: "Failed to fetch notes." });

--- a/src/public/assets/js/versioning.js
+++ b/src/public/assets/js/versioning.js
@@ -1,5 +1,5 @@
-let aurideVersion = "v2025.10.18";
-let aurideUpdate = "v20251018-1";
+let aurideVersion = "v2025.10.20";
+let aurideUpdate = "v20251020-1";
 let aurideReleaseVersion = "alpha";
 let hasUpdateNotes = true;
 

--- a/src/updates.html
+++ b/src/updates.html
@@ -66,6 +66,15 @@
                         <p>Trying to find older updates? You may be interested in the Pre-Alpha tab, since Auride is no longer in Pre-Alpha!</p>
 
                         <div class="update">
+                            <h2>v2025.10.20_alpha</h2>
+                            <h3 style="color: var(--text-semi-transparent);">Released: October 20, 2025</h3>
+                                <li>(Dev Env) Temporarily removed .slice() from server note rendering</li>
+                                <li>Fixed some users not showing up on the timeline</li>
+                        </div>
+                        
+                        <br />
+
+                        <div class="update">
                             <h2>v2025.10.18_alpha</h2>
                             <h3 style="color: var(--text-semi-transparent);">Released: October 18, 2025</h3>
                                 <li>Added filter to swap between loading all notes, or loading only notes from users you're following</li>


### PR DESCRIPTION
### Description of Changes
---
This PR simply removes the .slice() from the server note fetching, fixing an issue where some users would simply not show up on the timeline.

Took me an hour and a half to figure this out... seems like an issue with the server not returning newest->oldest, but Auride rendering them as newest->oldest (as returned from the server) so it looks like nothing is wrong, when there is something severely wrong.

### Visual Sample
---
After Fix:
<img width="967" height="815" alt="image" src="https://github.com/user-attachments/assets/01c0e033-2c5a-4696-90e3-8da6ed3d799d" />

Before Fix:
<img width="967" height="815" alt="image" src="https://github.com/user-attachments/assets/8fed16ad-5c53-49e8-88b4-1736952d54b4" />
(Should be notes after "i bought a skirt!")

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
  - You agree that you have tested your changes, and that you are not opening a Pull Request that you're unsure if it works.
- [x] I confirm I have not contributed anything that would impact Auride's licensing and/or usage
  - Auride is a **commercial** product that Katniny Studios can profit from. Please do not add copyrighted material to your Pull Request, however there are exceptions (e.g. our Spotify integration).
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
  - This includes things such as security vulnerabilities, ways to manipulate data, etc.
- [x] I've read the latest [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md) (last updated: September 15, 2025) and will follow the guidelines
  - Please make sure to read it, we use this as the standard when reviewing contributions, so it's in your best interest to be familiar with it!
- [x] I updated the version and added the update log
  - Unsure what this means? Please read [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md).