### PR TITLE
Start loading contributors from JSON

### DIFF
--- a/src/assets/css/contributors.css
+++ b/src/assets/css/contributors.css
@@ -1,16 +1,17 @@
 .contributor {
    display: flex;
    align-items: center;
-   margin-bottom: 20px;
-   border: 1px solid var(--note-background);
+   margin-bottom: 10px;
+   border: 1px solid var(--text-half-transparent);
    padding: 15px;
-   border-radius: 15px;
+   border-radius: 5px;
    transition: transform 0.2s ease;
    cursor: pointer;
 }
 
-.contributor:hover {
-   transform: translateY(-3px);
+.contributor:hover,
+.contributor:focus {
+   transform: translateY(-1px);
 }
 
 .profilePic {
@@ -31,4 +32,9 @@
    border-radius: 12px;
    font-size: 0.8em;
    margin-left: 5px;
+}
+
+.contributorsPageDesc {
+   margin-bottom: 10px;
+   color: var(--text-semi-transparent);
 }

--- a/src/contributors.html
+++ b/src/contributors.html
@@ -20,7 +20,7 @@
         <script src="/assets/js/scriptLoader.js"></script>
         <script defer>
             ScriptLoader.load(
-                //...
+                { src: "/assets/js/contributors.js", async: false }
             ).then(() => {
                 console.log("Scripts for /home have been loaded successfully.");
             }).catch((error) => {
@@ -53,83 +53,12 @@
 
             <div class="noteFilter">
                 <div class="blogStyle" style="margin: 15px;">
-                    <h1>Contributors</h1>
-                    <h3>Thank you to everyone who contributes for making Auride even better! :D</h3>
+                    <!-- content is dynamically added now :) -->
+                    <div id="contributors"></div>
 
                     <br />
 
-                    <h1>Main Contributors</h1>
-                    <p style="color: var(--text-semi-transparent);">They commit directly to Auride and are important to Auride!</p>
-                    <div class="contributor">
-                        <img src="https://best-energy-drink-is.fucking.monster/images/pfp/G6GaJr8vPpeVdvenAntjOFYlbwr2/IMG_2219.png" alt="katty pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <a href="/u/katniny" style="color: var(--main-color);">katty! <span class="badge">Main Developer/Founder</span></a>
-                            <span>(The main developer/founder of Auride)</span>
-                        </div>
-                    </div>
-
-                    <div class="contributor">
-                        <img src="https://best-energy-drink-is.fucking.monster/images/pfp/YFTD2TCF1kR3UVDmBNj9ExtFIbS2/8861df647c76ab3019c1eec11f0eed16.jpg" alt="georgiie___ pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <a href="/u/georgiie___" style="color: var(--main-color);">gigi ☆ <span class="badge">Created the Auride logos/styles</span></a>
-                            <span>(Created all the versions of the Auride logo)</span>
-                        </div>
-                    </div>
-
-                    <div class="contributor">
-                        <img src="https://best-energy-drink-is.fucking.monster/images/pfp/9TGDVYDPDTM4foIwWslq1x00qlg1/picrew-pfp.png" alt="demented goldfish pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <a href="/u/lunahd" style="color: var(--main-color);">lily   <span class="badge">Lead Contributor</span></a>
-                            <span>(Lead Contributor (Basically the co-developer))</span>
-                            <div style="margin-left: 15px;">She does a lot for Auride (thank you 🙏). You can see
-                                <a href="https://github.com/katniny/auride/commits?author=miku4k" target="_blank" style="color: var(--main-color);">all its amazing help here</a>.
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="contributor">
-                        <img src="https://github.com/evelynesides.png" alt="silly fingers in the shadow realm pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <a href="/u/evelynesides" style="color: var(--main-color);">EvelyneSides <span class="badge">Hosting</span></a>
-                            <span>(Storage Host)</span>
-                        </div>
-                    </div>
-
-                    <br />
-                    <br />
-
-                    <h1>External Contributors</h1>
-                    <p style="color: var(--text-semi-transparent);">They contribute to Auride in different ways, but are not directly involved in the development (e.g. provide services that don't qualify for our open source page). This doesn't make them any less important though!</p>
-                    <div class="contributor">
-                        <img src="https://best-energy-drink-is.fucking.monster/images/pfp/uPgnmADxuRUT2En5mL4QpS86Xaf1/512426602_10063340230430363_7120752397827842165_n.jpg" alt="mistycryssy pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <a href="/u/crystallinebaker" style="color: var(--main-color);">Crystal!! <span class="badge">Social Media Manager</span></a>
-                            <span>(Runs the social media accounts)</span>
-                        </div>
-                    </div>
-
-                    <div class="contributor">
-                        <img src="https://storage.ko-fi.com/cdn/useruploads/874ca35c-b1fa-4fd2-9765-c3392fe116fb.jpg" alt="Chereverie pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <a href="https://chereverie.art/" style="color: var(--main-color);">Chereverie <span class="badge">Created Aurora's art assets</span></a>
-                        </div>
-                    </div>
-
-                    <div class="contributor">
-                        <img src="/assets/imgs/DCs Cleaning Co Logo.png" alt="DCs Cleaning Co. pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <span style="color: var(--main-color);">DC's Cleaning Co. <span class="badge">Supports us financially</span></span>
-                            <span>(Don't worry - no shady deals! It's my mom, lol. Update Feb 21, 2025: Renewed transs.social for another year)</span>
-                        </div>
-                    </div>
-
-                    <div class="contributor">
-                        <img src="https://github.com/arthuro555.png" alt="arthuro555 pfp" class="profilePic" draggable="false" />
-                        <div class="contributorInfo">
-                            <a href="/u/arthuro555" style="color: var(--main-color);">arthuro555 <span class="badge">Found severe security exploits</span></a>
-                            <span>(Thank you for not abusing it and reporting them instead (and thank you Luna for fixing them))!</span>
-                        </div>
-                    </div>
+                    <div id="sponsors"></div>
 
                     <br />
 

--- a/src/public/assets/contributors.json
+++ b/src/public/assets/contributors.json
@@ -1,0 +1,54 @@
+{
+    "contributors": {
+        "1": {
+            "uid": "G6GaJr8vPpeVdvenAntjOFYlbwr2",
+            "contribution": "Main developer/founder of Auride"
+        },
+        "2": {
+            "uid": "YFTD2TCF1kR3UVDmBNj9ExtFIbS2",
+            "contribution": "Created Auride logos and occasionally creates marketing material"
+        },
+        "3": {
+            "uid": "9TGDVYDPDTM4foIwWslq1x00qlg1",
+            "contribution": "Contributed lots of things to Auride",
+            "extras": {
+                "seeCommits": "<a href='https://github.com/miku4k'>See all its amazing help here</a>"
+            }
+        },
+        "4": {
+            "uid": "w0YN3XV2mCRkNXJ2gNDYvCoTHtF3",
+            "contribution": "Storage sponsor and helped find security issues"
+        },
+        "5": {
+            "uid": "uPgnmADxuRUT2En5mL4QpS86Xaf1",
+            "contribution": "Runs the Auride Bluesky, Twitter, and TikTok social media accounts"
+        },
+        "6": {
+            "uid": "notOnAuride",
+            "contribution": "Created Aurora's art assets",
+            "extras": {
+                "offPlatformDisplay": "Chereverie",
+                "offPlatformPfp": "https://storage.ko-fi.com/cdn/useruploads/874ca35c-b1fa-4fd2-9765-c3392fe116fb.jpg",
+                "offPlatformLink": "https://chereverie.art/"
+            }
+        },
+        "7": {
+            "uid": "notOnAuride",
+            "contribution": "Runs the Auride Stripe account & occasionally helps with site costs",
+            "extras": {
+                "offPlatformDisplay": "DC's Cleaning Co.",
+                "offPlatformPfp": "/assets/imgs/DCs Cleaning Co Logo.png",
+                "offPlatformLink": "#"
+            }
+        }
+    },
+    "sponsors": {
+        "1": {
+            "uid": "w0YN3XV2mCRkNXJ2gNDYvCoTHtF3",
+            "contribution": "Storage sponsor and helped find security issues",
+            "extras": {
+                "website": "https://evelynesi.de/"
+            }
+        }
+    }
+}

--- a/src/public/assets/js/contributors.js
+++ b/src/public/assets/js/contributors.js
@@ -1,0 +1,114 @@
+async function getContributorsAndSponsors() {
+    const contributorsDiv = document.getElementById("contributors");
+    const sponsorsDiv = document.getElementById("sponsors");
+
+    // create loading indicator
+    createLoadingIndicator("sm", "contributors", "append");
+    const loadingIndicator = document.getElementById("noteLoadingIndicator");
+    loadingIndicator.innerHTML += "Finding contributors & sponsors...";
+
+    // fetch file
+    fetch(`/assets/contributors.json`)
+        .then(async res => {
+            if (!res.ok) {
+                const err = await res.text();
+                console.log(err);
+                contributorsDiv.innerHTML = `
+                    <h1>Something went wrong. :(</h1>
+                    <p>Please refresh the page, check your internet connection, or try again later.</p>
+                `;
+            }
+            return res.json();
+        }).then(data => {
+            const contributors = data.contributors;
+            const sponsors = data.sponsors;
+
+            contributorsDiv.innerHTML = `
+                <h1>Contributors</h1>
+                <p class="contributorsPageDesc">Everyone that contributed, or actively contributes, to Auride in some way.</p>
+            `;
+
+            sponsorsDiv.innerHTML = `
+                <h1>Sponsors</h1>
+                <p class="contributorsPageDesc">All of Auride's (awesome) sponsors. Please email <a href="mailto:katniny@proton.me">katniny@proton.me</a> if you're interested in sponsoring Auride.</p>
+            `;
+
+            // then, get contributors
+            Object.values(contributors).forEach(contributor => {
+                // if valid UID, get user data
+                // else, they're not on auride and we fill in that data
+                const contributorCard = document.createElement("div");
+                contributorCard.className = "contributor";
+
+                if (contributor.uid && contributor.uid !== "notOnAuride") {
+                    firebase.database().ref(`users/${contributor.uid}`).once("value", snapshot => {
+                        const data = snapshot.val();
+
+                        // set html
+                        contributorCard.innerHTML = `
+                            <img src="${storageLink(`images/pfp/${contributor.uid}/${data.pfp}`)}" alt="${data.username}'s profile picture" class="profilePic" draggable="false">
+                            <div class="contributorInfo">
+                                <a href="/u/${data.username}" class="userLink">${data.display}</a>
+                                <span>${contributor.contribution}</span>
+                            </div>
+                        `;
+                    }).catch((err) => {
+                        contributorCard.innerHTML = `
+                            <h3>Something went wrong fetching this contributor.</h3>
+                        `;
+                    });
+                } else {
+                    contributorCard.innerHTML = `
+                        <img src="${contributor.extras.offPlatformPfp}" alt="${contributor.extras.offPlatformDisplay}'s profile picture" class="profilePic" draggable="false">
+                        <div class="contributorInfo">
+                            <a href="${contributor.extras.offPlatformLink}" target="_blank" class="userLink">${contributor.extras.offPlatformDisplay}</a>
+                            <span>${contributor.contribution}</span>
+                        </div>
+                    `;
+                }
+
+                contributorsDiv.appendChild(contributorCard);
+            });
+
+            // rinse and repeat for sponsors
+            Object.values(sponsors).forEach(sponsor => {
+                // if valid UID, get user data
+                // else, they're not on auride and we fill in that data
+                const sponsorCard = document.createElement("div");
+                sponsorCard.className = "contributor";
+
+                if (sponsor.uid && sponsor.uid !== "notOnAuride") {
+                    firebase.database().ref(`users/${sponsor.uid}`).once("value", snapshot => {
+                        const data = snapshot.val();
+
+                        // set html
+                        sponsorCard.innerHTML = `
+                            <img src="${storageLink(`images/pfp/${sponsor.uid}/${data.pfp}`)}" alt="${data.username}'s profile picture" class="profilePic" draggable="false">
+                            <div class="contributorInfo">
+                                <a href="/u/${data.username}" class="userLink">${data.display}</a>
+                                <span>${sponsor.contribution}</span>
+                            </div>
+                        `;
+                    }).catch((err) => {
+                        sponsorCard.innerHTML = `
+                            <h3>Something went wrong fetching this sponsor.</h3>
+                        `;
+                    });
+                } else {
+                    sponsorCard.innerHTML = `
+                        <img src="${sponsor.extras.offPlatformPfp}" alt="${sponsor.extras.offPlatformDisplay}'s profile picture" class="profilePic" draggable="false">
+                        <div class="contributorInfo">
+                            <a href="${sponsor.extras.offPlatformLink}" target="_blank" class="userLink">${sponsor.extras.offPlatformDisplay}</a>
+                            <span>${sponsor.contribution}</span>
+                        </div>
+                    `;
+                }
+
+                sponsorsDiv.appendChild(sponsorCard);
+            });
+        }).catch(err => {
+            console.error(err);
+        });
+}
+
+getContributorsAndSponsors();

--- a/src/public/assets/js/envVars.js
+++ b/src/public/assets/js/envVars.js
@@ -6,7 +6,7 @@ const illegalUiPages = [
     "/auth/pfp",
     "/auth/policies",
     "/auth/register",
-    "/about",,
+    "/about",
     "/maintenance",
     "/suspended",
     "/unsupported"

--- a/src/public/assets/js/versioning.js
+++ b/src/public/assets/js/versioning.js
@@ -1,5 +1,5 @@
-let aurideVersion = "v2025.10.30";
-let aurideUpdate = "v20251030-1";
+let aurideVersion = "v2025.11.3";
+let aurideUpdate = "v20251103-1";
 let aurideReleaseVersion = "alpha";
 let hasUpdateNotes = true;
 

--- a/src/updates.html
+++ b/src/updates.html
@@ -66,6 +66,15 @@
                         <p>Trying to find older updates? You may be interested in the Pre-Alpha tab, since Auride is no longer in Pre-Alpha!</p>
 
                         <div class="update">
+                            <h2>v2025.11.3_alpha</h2>
+                            <h3 style="color: var(--text-semi-transparent);">Released: November 3, 2025</h3>
+                                <li>(Dev Env) Started loading <a href="/contributors">contributors</a> from a JSON file</li>
+                                <li>Improved UI on the contributors page</li>
+                        </div>
+                        
+                        <br />
+                        
+                        <div class="update">
                             <h2>v2025.10.30_alpha</h2>
                             <h3 style="color: var(--text-semi-transparent);">Released: October 30, 2025</h3>
                                 <li>(Dev Env) Unify Auride Accounts HTML/functionality</li>


### PR DESCRIPTION
### Description of Changes
---
This PR starts loading the contributors from a .json file in /assets so we don't have to manually change contributors when they update their profile (which I slacked on), unless they do not have an Auride profile.

### Visual Sample
---
<img width="984" height="898" alt="image" src="https://github.com/user-attachments/assets/ca2a322c-edc4-4637-918e-6842dfc3d0b8" />

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
  - You agree that you have tested your changes, and that you are not opening a Pull Request that you're unsure if it works.
- [x] I confirm I have not contributed anything that would impact Auride's licensing and/or usage
  - Auride is a **commercial** product that Katniny Studios can profit from. Please do not add copyrighted material to your Pull Request, however there are exceptions (e.g. our Spotify integration).
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
  - This includes things such as security vulnerabilities, ways to manipulate data, etc.
- [x] I've read the latest [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md) (last updated: September 15, 2025) and will follow the guidelines
  - Please make sure to read it, we use this as the standard when reviewing contributions, so it's in your best interest to be familiar with it!
- [x] I updated the version and added the update log
  - Unsure what this means? Please read [CONTRIBUTING.md](https://github.com/katniny/auride/blob/main/CONTRIBUTING.md).